### PR TITLE
Upgrade Detekt from 1.23.8 to 2.0.0-alpha.2

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import io.gitlab.arturbosch.detekt.Detekt
+import dev.detekt.gradle.Detekt
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -10,7 +10,7 @@ plugins {
 
 subprojects {
     apply(plugin = "org.jlleitschuh.gradle.ktlint")
-    apply(plugin = "io.gitlab.arturbosch.detekt")
+    apply(plugin = "dev.detekt")
 
     group = "com.pkware.detekt"
 
@@ -49,10 +49,10 @@ subprojects {
     }
 
     tasks.withType<Detekt>().configureEach {
-        jvmTarget = tasks.named<KotlinCompile>("compileKotlin").get().compilerOptions.jvmTarget.get().target
-        parallel = true
+        jvmTarget.set("21")
+        parallel.set(true)
         config.from(rootProject.file("detekt.yml"))
-        buildUponDefaultConfig = true
+        buildUponDefaultConfig.set(true)
     }
 }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -136,7 +136,7 @@ style:
     active: true
   ForbiddenImport:
     active: true
-    imports:
+    forbiddenImports:
       - 'org.junit.Assert'
       - 'org.junit.Test'
       - 'org.junit.Before'
@@ -144,7 +144,6 @@ style:
       - 'org.junit.After'
       - 'org.junit.AfterClass'
       - 'org.junit.jupiter.api.Assertions'
-    forbiddenPatterns: '(?:junit\.framework|org\.junit\.jupiter\.api\.Assertions)\.(?!assertThrows).+'
   ForbiddenComment:
     comments:
       - reason: 'Forbidden FIXME todo marker in comment, please fix the problem.'
@@ -183,11 +182,11 @@ style:
     active: true
   RedundantExplicitType:
     active: true
-  RedundantVisibilityModifierRule:
+  RedundantVisibilityModifier:
     active: false
   ReturnCount:
     active: false
-  SpacingBetweenPackageAndImports:
+  SpacingAfterPackageDeclaration:
     active: true
   UnderscoresInNumericLiterals:
     active: true
@@ -199,7 +198,7 @@ style:
     active: false
   UnnecessaryLet:
     active: true
-  UntilInsteadOfRangeTo:
+  RangeUntilInsteadOfRangeTo:
     active: true
   UseEmptyCounterpart:
     active: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,14 +1,15 @@
 [versions]
 junitVersion = "6.0.3"
-detektVersion = "1.23.8"
+detektVersion = "2.0.0-alpha.2"
 kspVersion = "2.3.6"
 ktlintVersion = "14.2.0"
 
 [libraries]
-detekt-tooling = { module = "io.gitlab.arturbosch.detekt:detekt-tooling", version.ref = "detektVersion" }
-detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detektVersion" }
-detekt-test = { module = "io.gitlab.arturbosch.detekt:detekt-test", version.ref = "detektVersion" }
-detekt-parser = { module = "io.gitlab.arturbosch.detekt:detekt-parser", version.ref = "detektVersion" }
+detekt-tooling = { module = "dev.detekt:detekt-tooling", version.ref = "detektVersion" }
+detekt-api = { module = "dev.detekt:detekt-api", version.ref = "detektVersion" }
+detekt-test = { module = "dev.detekt:detekt-test", version.ref = "detektVersion" }
+detekt-parser = { module = "dev.detekt:detekt-parser", version.ref = "detektVersion" }
+detekt-psi-utils = { module = "dev.detekt:detekt-psi-utils", version.ref = "detektVersion" }
 junit-jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "junitVersion" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "junitVersion" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher", version = "6.0.3" }
@@ -20,4 +21,4 @@ auto-service-annotations = "com.google.auto.service:auto-service-annotations:1.1
 [plugins]
 ksp = { id = "com.google.devtools.ksp", version.ref = "kspVersion"  }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlintVersion" }
-detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detektVersion" }
+detekt = { id = "dev.detekt", version.ref = "detektVersion" }

--- a/import-extension/build.gradle.kts
+++ b/import-extension/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation(libs.auto.service.annotations)
     implementation(libs.detekt.tooling)
     implementation(libs.detekt.api)
+    implementation(libs.detekt.psi.utils)
 
     testImplementation(libs.detekt.test)
     testImplementation(libs.detekt.parser)

--- a/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/EnforceStaticImport.kt
+++ b/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/EnforceStaticImport.kt
@@ -1,20 +1,20 @@
 package com.pkware.detekt.extensions.rules.staticImport
 
-import io.github.detekt.tooling.api.FunctionMatcher
-import io.gitlab.arturbosch.detekt.api.CodeSmell
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Debt
-import io.gitlab.arturbosch.detekt.api.Entity
-import io.gitlab.arturbosch.detekt.api.Issue
-import io.gitlab.arturbosch.detekt.api.Rule
-import io.gitlab.arturbosch.detekt.api.Severity
-import io.gitlab.arturbosch.detekt.api.config
-import io.gitlab.arturbosch.detekt.api.internal.Configuration
-import io.gitlab.arturbosch.detekt.api.internal.RequiresTypeResolution
+import dev.detekt.api.Config
+import dev.detekt.api.Configuration
+import dev.detekt.api.Entity
+import dev.detekt.api.Finding
+import dev.detekt.api.RequiresAnalysisApi
+import dev.detekt.api.Rule
+import dev.detekt.api.config
+import dev.detekt.psi.FunctionMatcher
+import org.jetbrains.kotlin.analysis.api.analyze
+import org.jetbrains.kotlin.analysis.api.resolution.singleFunctionCallOrNull
+import org.jetbrains.kotlin.analysis.api.resolution.symbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaCallableSymbol
+import org.jetbrains.kotlin.analysis.api.symbols.KaNamedFunctionSymbol
 import org.jetbrains.kotlin.psi.KtCallExpression
-import org.jetbrains.kotlin.psi.KtExpression
-import org.jetbrains.kotlin.resolve.BindingContext
-import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
 
 /**
  * This detekt extension rule allows to set a list of methods that should be statically imported. This can be used to
@@ -22,21 +22,15 @@ import org.jetbrains.kotlin.resolve.calls.util.getResolvedCall
  *
  * Detekt will then report all method invocations that that should be statically linked.
  *
- * This rule requires detekt to be run with a context defined for type resolution. This helps resolve incoming method
+ * This rule requires detekt to be run with type resolution enabled. This helps resolve incoming method
  * calls to be checked against the list of methods that should be statically imported.
  *
  * @param config The detekt configuration passed into this rule.
  * The configuration can override the default methods used here that should be statically linked
  */
-@RequiresTypeResolution
-class EnforceStaticImport(config: Config = Config.empty) : Rule(config) {
-    override val issue =
-        Issue(
-            javaClass.simpleName,
-            Severity.Style,
-            "Method should be imported statically.",
-            Debt.TEN_MINS,
-        )
+class EnforceStaticImport(config: Config = Config.empty) :
+    Rule(config, "Method should be imported statically."),
+    RequiresAnalysisApi {
 
     @Configuration(
         "Comma separated list of fully qualified method signatures which should be statically imported. " +
@@ -48,40 +42,24 @@ class EnforceStaticImport(config: Config = Config.empty) : Rule(config) {
     private val methods: List<FunctionMatcher> by config(listOf("")) { it.map(FunctionMatcher::fromFunctionSignature) }
 
     /**
-     * A call expression is triggered for a method and/or function call.
-     * @see <a href="https://kotlinlang.org/spec/expressions.html#call-and-property-access-expressions">https://kotlinlang.org/spec/expressions.html#call-and-property-access-expressions</a>
+     * A dot-qualified expression triggers for method calls with an explicit receiver (e.g. `Math.floor(x)`).
+     * We only report these — calls without an explicit receiver are already statically imported.
      */
-    override fun visitCallExpression(expression: KtCallExpression) {
-        super.visitCallExpression(expression)
-        check(expression)
-    }
+    override fun visitDotQualifiedExpression(expression: KtDotQualifiedExpression) {
+        super.visitDotQualifiedExpression(expression)
+        val callExpression = expression.selectorExpression as? KtCallExpression ?: return
 
-    /**
-     * Analyze an incoming [KtExpression] and generate a detekt code smell error if the expression's resolved method
-     * matches a method in our list that should be statically linked.
-     *
-     * This method will not detect any code smells if there is no binding context setup before it is called.
-     * @see EnforceStaticImport class definition
-     *
-     * @param expression The incoming [KtExpression] to analyze
-     */
-    private fun check(expression: KtExpression) {
-        if (bindingContext == BindingContext.EMPTY) return
+        analyze(callExpression) {
+            val symbol = callExpression.resolveToCall()?.singleFunctionCallOrNull()?.symbol ?: return@analyze
 
-        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
-
-        val isStaticImport = resolvedCall.call.explicitReceiver == null
-        if (isStaticImport) return
-
-        val descriptors =
-            resolvedCall.resultingDescriptor.let {
-                listOf(it) + it.overriddenDescriptors
+            val allSymbols: List<KaCallableSymbol> = buildList {
+                add(symbol)
+                if (symbol is KaNamedFunctionSymbol) addAll(symbol.allOverriddenSymbols.toList())
             }
 
-        for (descriptor in descriptors) {
-            methods.find { it.match(descriptor) }?.let { functionMatcher ->
-                val message = "$functionMatcher needs to be statically imported."
-                report(CodeSmell(issue, Entity.from(expression), message))
+            val matcher = allSymbols.firstNotNullOfOrNull { sym -> methods.find { it.match(sym) } }
+            if (matcher != null) {
+                report(Finding(Entity.from(callExpression), "$matcher needs to be statically imported."))
             }
         }
     }

--- a/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/ImportConfigValidator.kt
+++ b/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/ImportConfigValidator.kt
@@ -1,10 +1,10 @@
 package com.pkware.detekt.extensions.rules.staticImport
 
 import com.google.auto.service.AutoService
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.Config.InvalidConfigurationError
-import io.gitlab.arturbosch.detekt.api.ConfigValidator
-import io.gitlab.arturbosch.detekt.api.Notification
+import dev.detekt.api.Config
+import dev.detekt.api.Config.InvalidConfigurationError
+import dev.detekt.api.ConfigValidator
+import dev.detekt.api.Notification
 
 /**
  * Validates the config setup for the detekt custom import ruleset within detekt.yml.
@@ -22,21 +22,17 @@ import io.gitlab.arturbosch.detekt.api.Notification
  */
 @AutoService(ConfigValidator::class)
 class ImportConfigValidator : ConfigValidator {
+    override val id: String = "ImportConfigValidator"
+
     override fun validate(config: Config): Collection<Notification> {
         val result = mutableListOf<Notification>()
         try {
             config.subConfig("import")
                 .subConfig("EnforceStaticImport")
-                .valueOrNull<Boolean>("active")
+                .valueOrNull("active")
         } catch (expected: InvalidConfigurationError) {
-            result.add(Message("'active' property must be of type boolean."))
+            result.add(Notification("'active' property must be of type boolean.", Notification.Level.Error))
         }
         return result
     }
 }
-
-/**
- * Provides a message string and a notification level for the detekt linter.
- */
-class Message(override val message: String, override val level: Notification.Level = Notification.Level.Error) :
-    Notification

--- a/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/ImportExtensionProvider.kt
+++ b/import-extension/src/main/kotlin/com/pkware/detekt/extensions/rules/staticImport/ImportExtensionProvider.kt
@@ -1,9 +1,10 @@
 package com.pkware.detekt.extensions.rules.staticImport
 
 import com.google.auto.service.AutoService
-import io.gitlab.arturbosch.detekt.api.Config
-import io.gitlab.arturbosch.detekt.api.RuleSet
-import io.gitlab.arturbosch.detekt.api.RuleSetProvider
+import dev.detekt.api.RuleName
+import dev.detekt.api.RuleSet
+import dev.detekt.api.RuleSetId
+import dev.detekt.api.RuleSetProvider
 
 /**
  * The import extension rule set provider for this detekt extension.
@@ -11,7 +12,8 @@ import io.gitlab.arturbosch.detekt.api.RuleSetProvider
  */
 @AutoService(RuleSetProvider::class)
 class ImportExtensionProvider : RuleSetProvider {
-    override val ruleSetId: String = "import"
+    override val ruleSetId: RuleSetId = RuleSetId("import")
 
-    override fun instance(config: Config): RuleSet = RuleSet(ruleSetId, listOf(EnforceStaticImport(config)))
+    override fun instance(): RuleSet =
+        RuleSet(ruleSetId, mapOf(RuleName("EnforceStaticImport") to ::EnforceStaticImport))
 }

--- a/import-extension/src/test/kotlin/com/pkware/detekt/extensions/rules/staticImport/EnforceStaticImportTest.kt
+++ b/import-extension/src/test/kotlin/com/pkware/detekt/extensions/rules/staticImport/EnforceStaticImportTest.kt
@@ -1,51 +1,30 @@
 package com.pkware.detekt.extensions.rules.staticImport
 
-import com.google.common.truth.Truth
-import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
-import io.github.detekt.test.utils.createEnvironment
-import io.gitlab.arturbosch.detekt.api.SourceLocation
-import io.gitlab.arturbosch.detekt.test.TestConfig
-import io.gitlab.arturbosch.detekt.test.assertThat
-import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
-import org.jetbrains.kotlin.cli.jvm.compiler.KotlinCoreEnvironment
-import org.junit.jupiter.api.AfterEach
+import com.google.common.truth.Truth.assertThat
+import dev.detekt.api.SourceLocation
+import dev.detekt.test.TestConfig
+import dev.detekt.test.lintWithContext
+import dev.detekt.test.location
+import dev.detekt.test.utils.KotlinEnvironmentContainer
+import dev.detekt.test.utils.createEnvironment
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.params.provider.Arguments
-import java.io.File
 
 private const val METHODS = "methods"
 
 class EnforceStaticImportTest {
-    private lateinit var wrapper: KotlinCoreEnvironmentWrapper
-    private lateinit var env: KotlinCoreEnvironment
+    private lateinit var env: KotlinEnvironmentContainer
 
-    // We need to set up a custom KotlinCoreEnvironment and add the Truth and Arguments class paths to that environment,
-    // so they are available to generate the BindingContext for detekt rules under test with the
-    // EnforceStaticImportExtension.
     @BeforeEach
     fun setUp() {
-        wrapper =
-            createEnvironment(
-                additionalRootPaths =
-                listOf(
-                    File(Truth::class.java.protectionDomain.codeSource.location.path),
-                    File(Arguments::class.java.protectionDomain.codeSource.location.path),
-                ),
-            )
-        env = wrapper.env
-    }
-
-    @AfterEach
-    fun tearDown() {
-        wrapper.dispose()
+        env = createEnvironment()
     }
 
     @Test
     fun `rule report based on custom configuration`() {
         val code = """
             fun main() {
-                val value = 3.3
+                var value = 3.3
                 value = Math.floor(value)
                 print("3")
             }
@@ -54,24 +33,21 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.lang.Math.floor", "kotlin.io.print"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(4, 30)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].location.source).isEqualTo(SourceLocation(4, 30))
     }
 
     @Test
-    fun `rule report truth and arguments`() {
+    fun `rule report with multiple equivalent static import methods`() {
         val code = """
-            import com.google.common.truth.Truth
-            import com.google.common.truth.Truth.assertThat
-            import org.junit.jupiter.params.provider.Arguments
+            import java.lang.Math.floor
             fun main() {
-                val value = 3
-                Truth.assertThat(value).isEqualTo(3)
-                assertThat(value).isNotEqualTo(4)
-                val args = Arguments.arguments("test", "test2")
+                val value = 3.0
+                Math.floor(value)
+                floor(value)
+                java.time.LocalDate.now()
             }
             """
 
@@ -81,17 +57,17 @@ class EnforceStaticImportTest {
                     Pair(
                         METHODS,
                         listOf(
-                            "com.google.common.truth.Truth.assertThat",
-                            "org.junit.jupiter.params.provider.Arguments.arguments",
+                            "java.lang.Math.floor",
+                            "java.time.LocalDate.now",
                         ),
                     ),
                 ),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasStartSourceLocations(
-            SourceLocation(7, 23),
-            SourceLocation(9, 38),
+        assertThat(findings.map { it.location.source }).containsExactly(
+            SourceLocation(5, 22),
+            SourceLocation(7, 37),
         )
     }
 
@@ -107,18 +83,17 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.lang.Math.floor"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(4, 40)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].location.source).isEqualTo(SourceLocation(4, 40))
     }
 
     @Test
-    fun `rule report with multiple different methods when config is a string`() {
+    fun `rule report with multiple different methods`() {
         val code = """
             fun main() {
-                value = 3.7
+                var value = 3.7
                 value = Math.floor(value)
                 System.gc()
             }
@@ -126,11 +101,11 @@ class EnforceStaticImportTest {
 
         val findings =
             EnforceStaticImport(
-                TestConfig(Pair(METHODS, "java.lang.Math.floor, java.lang.System.gc")),
-            ).compileAndLintWithContext(env, code)
+                TestConfig(Pair(METHODS, listOf("java.lang.Math.floor", "java.lang.System.gc"))),
+            ).lintWithContext(env, code)
 
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasStartSourceLocations(
+        assertThat(findings.map { it.location.source }).containsExactly(
             SourceLocation(4, 30),
             SourceLocation(5, 24),
         )
@@ -149,10 +124,10 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.time.LocalDate.now"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasStartSourceLocations(
+        assertThat(findings.map { it.location.source }).containsExactly(
             SourceLocation(5, 34),
             SourceLocation(6, 35),
         )
@@ -171,11 +146,10 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.time.LocalDate.now()"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(5, 38)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].location.source).isEqualTo(SourceLocation(5, 38))
     }
 
     @Test
@@ -191,11 +165,10 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.time.LocalDate.now(java.time.Clock)"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(6, 39)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].location.source).isEqualTo(SourceLocation(6, 39))
     }
 
     @Test
@@ -208,11 +181,10 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.time.LocalDate.of(kotlin.Int, kotlin.Int, kotlin.Int)"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
-        assertThat(findings)
-            .hasSize(1)
-            .hasStartSourceLocation(3, 38)
+        assertThat(findings).hasSize(1)
+        assertThat(findings[0].location.source).isEqualTo(SourceLocation(3, 38))
     }
 
     @Test
@@ -238,10 +210,10 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("com.pkware.test.Example.Companion.`some, test`()"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasStartSourceLocations(
+        assertThat(findings.map { it.location.source }).containsExactly(
             SourceLocation(14, 38),
             SourceLocation(15, 48),
         )
@@ -277,10 +249,10 @@ class EnforceStaticImportTest {
                         ),
                     ),
                 ),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
         assertThat(findings).hasSize(2)
-        assertThat(findings).hasStartSourceLocations(
+        assertThat(findings.map { it.location.source }).containsExactly(
             SourceLocation(14, 38),
             SourceLocation(15, 48),
         )
@@ -290,7 +262,7 @@ class EnforceStaticImportTest {
     fun `no rule report if configuration methods are blank`() {
         val code = """
             fun main() {
-                value = 3.7
+                var value = 3.7
                 value = Math.floor(value)
                 print("3")
             }
@@ -298,8 +270,8 @@ class EnforceStaticImportTest {
 
         val findings =
             EnforceStaticImport(
-                TestConfig(Pair(METHODS, "  ")),
-            ).compileAndLintWithContext(env, code)
+                TestConfig(Pair(METHODS, listOf("  "))),
+            ).lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }
@@ -316,7 +288,7 @@ class EnforceStaticImportTest {
         val findings =
             EnforceStaticImport(
                 TestConfig(Pair(METHODS, listOf("java.lang.System.gc"))),
-            ).compileAndLintWithContext(env, code)
+            ).lintWithContext(env, code)
 
         assertThat(findings).isEmpty()
     }


### PR DESCRIPTION
Detekt 2.0 changed its Maven coordinates from io.gitlab.arturbosch.detekt to dev.detekt, migrated from K1 (BindingContext/descriptors) to the K2 Kotlin Analysis API, and made several API breaking changes.

Build changes:
- All detekt artifact coordinates updated to dev.detekt group
- Added detekt-psi-utils dependency (FunctionMatcher moved there from tooling)
- Detekt Gradle task properties migrated to lazy API: parallel.set(), jvmTarget.set(), buildUponDefaultConfig.set()
- Plugin IDs updated from io.gitlab.arturbosch.detekt to dev.detekt

Source changes:
- EnforceStaticImport: migrated from visitCallExpression + BindingContext to visitDotQualifiedExpression + analyze { resolveToCall().singleFunctionCallOrNull() } using the K2 Analysis API; Rule now takes description in constructor instead of an issue property; CodeSmell replaced by Finding
- ImportExtensionProvider: instance() no longer takes Config; ruleSetId is now RuleSetId type; RuleSet now takes Map<RuleName, (Config) -> Rule> not List<Rule>
- ImportConfigValidator: Notification changed from interface to final class; added required id property from Extension interface
- EnforceStaticImportTest: migrated to KotlinEnvironmentContainer / lintWithContext; external library tests replaced with JDK equivalents since the new test engine only includes JDK, stdlib, and coroutines in the analysis session

Config changes (detekt.yml):
- ForbiddenImport: imports -> forbiddenImports, removed forbiddenPatterns
- RedundantVisibilityModifierRule -> RedundantVisibilityModifier
- SpacingBetweenPackageAndImports -> SpacingAfterPackageDeclaration
- UntilInsteadOfRangeTo -> RangeUntilInsteadOfRangeTo