### PR TITLE
Prepare next development version

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,7 +14,7 @@ org.gradle.caching=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8
 kotlin.code.style=official
 
-detektExtensionVersion=2.0.0
+detektExtensionVersion=2.1.0-SNAPSHOT
 
 POM_NAME=Detekt Extensions
 POM_DESCRIPTION=A Detekt Extension Library


### PR DESCRIPTION
Bump version to `2.1.0-SNAPSHOT` after the 2.0.0 release.

Merge after pkware/detektExtensions#70 is merged and the artifact is promoted on Sonatype.